### PR TITLE
Add functionality to match job listings with relevant CVs and display them

### DIFF
--- a/actions/employer/get-matching-job-cvs.ts
+++ b/actions/employer/get-matching-job-cvs.ts
@@ -57,6 +57,18 @@ export const getMatchingJobsCvs = async ({
                   mode: "insensitive",
                 },
               },
+              {
+                cvHeadLine: {
+                  contains: jobTitle ? jobTitle.toLowerCase() : undefined,
+                  mode: "insensitive",
+                },
+              },
+              {
+                cvHeadLine: {
+                  contains: occupation ? occupation.toLowerCase() : undefined,
+                  mode: "insensitive",
+                },
+              },
             ],
           },
         },

--- a/actions/employer/get-matching-job-cvs.ts
+++ b/actions/employer/get-matching-job-cvs.ts
@@ -1,0 +1,86 @@
+import { db } from "@/lib/db";
+import { getLatestFileMetaData } from "../get-latest-file-metadata";
+import { getUserCv } from "../get-user-cv";
+import {
+  EducationLevel,
+  Experience,
+  GCPData,
+  JobSeekerProfile,
+  Profile,
+  Role,
+  Sector,
+  Skill,
+  User,
+} from "@prisma/client";
+type Props = {
+  jobTitle: string;
+  occupation: string;
+};
+
+type JobSeekerProfileType =
+  | (JobSeekerProfile & {
+      sector: Sector | null;
+      education: EducationLevel | null;
+      experience: Experience | null;
+      skills: Skill[] | null;
+    })
+  | null;
+
+type candidate =
+  | (User & {
+      profile: Profile | null;
+      jobSeekerProfile: JobSeekerProfileType;
+      //   cvFile: GCPData | null;
+    })
+  | null;
+
+export const getMatchingJobsCvs = async ({
+  jobTitle,
+  occupation,
+}: Props): Promise<candidate[]> => {
+  try {
+    const candidates = await db.user.findMany({
+      where: {
+        role: Role.JOB_SEEKER,
+        AND: {
+          jobSeekerProfile: {
+            OR: [
+              {
+                occupation: {
+                  contains: jobTitle ? jobTitle.toLowerCase() : undefined,
+                  mode: "insensitive",
+                },
+              },
+              {
+                occupation: {
+                  contains: occupation ? occupation.toLowerCase() : undefined,
+                  mode: "insensitive",
+                },
+              },
+            ],
+          },
+        },
+      },
+      include: {
+        profile: true,
+        jobSeekerProfile: {
+          include: {
+            sector: true,
+            education: true,
+            experience: true,
+            skills: true,
+          },
+        },
+      },
+    });
+    for (const candidate of candidates) {
+      const cv = await getUserCv(candidate.id);
+      const cvFile = await getLatestFileMetaData(cv?.id);
+      Object.assign(candidate, { cvFile });
+    }
+    return candidates;
+  } catch (error) {
+    console.log("[GET_ALL_CANDIDATES]", error);
+    return [];
+  }
+};

--- a/app/(root)/find-candidates/page.tsx
+++ b/app/(root)/find-candidates/page.tsx
@@ -48,9 +48,7 @@ interface SearchPageProps {
 const page = async ({ searchParams }: SearchPageProps) => {
   const hasParams = Object.keys(searchParams).length > 0;
   const user = await getCurrentSessionUser();
-  // if (!user || !(user.role === Role.EMPLOYER)) {
-  //   return redirect("/auth/signup/employer?callBack=/find-candidates");
-  // }
+
   const loggedInEmployer = user?.id && user?.role === Role.EMPLOYER;
   const candidates = await getAllCandidates({
     ...searchParams,
@@ -89,7 +87,7 @@ const page = async ({ searchParams }: SearchPageProps) => {
               <CandidateList
                 candidates={items}
                 candidateIds={candidateIds}
-                loggedInEmployer={loggedInEmployer || false}  
+                loggedInEmployer={loggedInEmployer || false}
               />
             </div>
           </section>
@@ -101,7 +99,7 @@ const page = async ({ searchParams }: SearchPageProps) => {
         />
       </div>
       {!hasParams && (
-        <div className="flex items-center justify-center bg-sky-100 md:p-20 mt-4">
+        <div className="mt-4 flex items-center justify-center bg-sky-100 md:p-20">
           <div className="basis-2/3">
             <h2 className="my-6 text-2xl">Frequently Asked Questions</h2>
             <Accordion type="single" collapsible defaultValue={cvFaqs[0].title}>

--- a/components/find-candidates/ActionsComponent.tsx
+++ b/components/find-candidates/ActionsComponent.tsx
@@ -25,6 +25,7 @@ import {
   CheckCircle,
   CircleSlash2,
   Download,
+  EllipsisVertical,
   FileText,
   Mail,
   Phone,
@@ -64,22 +65,7 @@ const ActionsComponent = ({
     <div>
       <Popover>
         <PopoverTrigger>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            className="lucide lucide-ellipsis-vertical"
-          >
-            <circle cx="12" cy="12" r="1" />
-            <circle cx="12" cy="5" r="1" />
-            <circle cx="12" cy="19" r="1" />
-          </svg>
+          <EllipsisVertical />
         </PopoverTrigger>
         <PopoverContent>
           <ul className="space-y-2">

--- a/components/find-candidates/CandidateList.tsx
+++ b/components/find-candidates/CandidateList.tsx
@@ -1,59 +1,42 @@
-import {
-  Candidate,
-  EducationLevel,
-  Experience,
-  JobSeekerProfile,
-  Profile,
-  Sector,
-  Skill,
-  User,
-} from "@prisma/client";
+import { Candidate } from "@prisma/client";
 import {
   Briefcase,
   CalendarDaysIcon,
-  CheckCircle,
-  File,
-  FileText,
   Flag,
   GraduationCap,
   Hammer,
-  Mail,
-  Phone,
-  Printer,
   UserSquareIcon,
 } from "lucide-react";
-import AddCandidateForm from "@/components/find-candidates/AddCandidateForm";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
-import { Button } from "../ui/button";
-import PDFViewer from "../PDFViewer";
+
 import { format } from "date-fns";
 import ActionsComponent from "./ActionsComponent";
 import { candidate } from "@/actions/get-all-candidates";
+import { cn } from "@/lib/utils";
 
 type Props = {
   candidates: candidate[] | null;
   candidateIds: Candidate[] | null;
   loggedInEmployer: boolean;
+  hasBackground?: boolean;
+  cardBg?: string;
 };
 
 const CandidateList = ({
   candidates,
   candidateIds,
   loggedInEmployer,
+  hasBackground = true,
+  cardBg,
 }: Props) => {
   return (
-    <div className="flex flex-col gap-4 bg-slate-100">
+    <div className={cn("flex flex-col gap-4", hasBackground && "bg-slate-100")}>
       {candidates?.map((candidate) => (
         <div
           key={candidate?.id}
-          className="space-y-4 rounded-md p-4 shadow-[rgba(50,_50,_105,_0.15)_0px_2px_5px_0px,_rgba(0,_0,_0,_0.05)_0px_1px_1px_0px]"
+          className={cn(
+            "space-y-4 rounded-md p-4 shadow-[rgba(50,_50,_105,_0.15)_0px_2px_5px_0px,_rgba(0,_0,_0,_0.05)_0px_1px_1px_0px]",
+            cardBg,
+          )}
         >
           <div className="flex justify-between border-b border-b-slate-400 py-4">
             <p className="flex items-center gap-2 text-[0.9rem] font-semibold">
@@ -67,97 +50,17 @@ const CandidateList = ({
               candidate={candidate}
               loggedInEmployer={loggedInEmployer}
             />
-
-            {/* <Dialog>
-              <DialogTrigger>
-                <FileText className="h-8 w-8 text-primary" />
-              </DialogTrigger>
-              <DialogContent className="max-w-[75%]">
-                <DialogHeader>
-                  <DialogTitle>
-                    <div className="flex justify-between bg-sky-100 p-4">
-                      <div>
-                        <Dialog>
-                          <DialogTrigger>
-                            <div className="flex flex-col gap-2">
-                              <p>Contact</p>
-                              <Button className="inline-flex items-center justify-center">
-                                <UserSquareIcon className="h-4 w-4 text-white" />
-                              </Button>
-                            </div>
-                          </DialogTrigger>
-                          <DialogContent>
-                            <DialogHeader>
-                              <DialogTitle>
-                                {`${candidate?.profile?.firstName} ${candidate?.profile?.lastName}` ||
-                                  "Candidate Name"}
-                              </DialogTitle>
-                              <DialogDescription>
-                                <a
-                                  href="mailto:{candidate?.email}"
-                                  className="flex items-center gap-2"
-                                >
-                                  Email
-                                  {candidate?.email && (
-                                    <Mail className="h-4 w-4 text-secondary" />
-                                  )}
-                                </a>
-                                <a
-                                  href="tel:{candidate?.profile?.phoneNumber}"
-                                  className="flex items-center gap-2"
-                                >
-                                  Phone
-                                  {candidate?.profile?.phoneNumber && (
-                                    <Phone className="h-4 w-4 text-secondary" />
-                                  )}
-                                </a>
-                              </DialogDescription>
-                            </DialogHeader>
-                          </DialogContent>
-                        </Dialog>
-                      </div>
-                      <div className="flex flex-col gap-2">
-                        <p>Reachability</p>
-                        <div className="flex flex-1 items-center justify-center gap-2">
-                          {candidate?.email && (
-                            <Mail className="h-6 w-6 text-secondary" />
-                          )}
-                          {candidate?.profile.phoneNumber && (
-                            <Phone className="h-6 w-6 text-secondary" />
-                          )}
-                        </div>
-                      </div>
-                      <div className="flex flex-col gap-2">
-                        <p>Save CV</p>
-                        <AddCandidateForm candidateId={candidate?.id} />
-                      </div>
-                      <div className="flex flex-col gap-2">
-                        <p>Print</p>
-                        <div className="flex flex-1 items-center justify-center gap-2">
-                          <Printer className="h-8 w-8 text-secondary" />
-                        </div>
-                      </div>
-                    </div>
-                  </DialogTitle>
-                  <DialogDescription>
-                    <PDFViewer pdfUrl={candidate.cvFile.downloadUrl} />
-                  </DialogDescription>
-                </DialogHeader>
-              </DialogContent>
-            </Dialog> */}
-            {/* </>
-            )} */}
           </div>
           <div className="">
             <div className="">
               <div className="flex items-center justify-between">
                 <p className="flex items-center gap-2 text-[0.9rem] font-semibold">
                   <UserSquareIcon className="h-4 w-4 text-primary" />
-                  {candidate?.jobSeekerProfile.cvHeadLine}
+                  {candidate?.jobSeekerProfile?.cvHeadLine}
                 </p>
                 <div className="flex items-center gap-2 text-[0.8rem] text-zinc-700">
                   <CalendarDaysIcon className="h-4 w-4 text-primary" />
-                  {candidate?.jobSeekerProfile.updatedAt
+                  {candidate?.jobSeekerProfile?.updatedAt
                     ? format(
                         new Date(candidate.jobSeekerProfile.updatedAt),
                         "MMM d, yyyy",
@@ -179,7 +82,7 @@ const CandidateList = ({
               </p>
               <div className="flex items-center gap-2 text-[0.8rem] text-zinc-700">
                 <Hammer className="h-4 w-4 text-primary" />
-                {candidate?.jobSeekerProfile.skills && (
+                {candidate?.jobSeekerProfile?.skills && (
                   <div className="space-x-2">
                     {candidate?.jobSeekerProfile.skills.map((skill) => (
                       <span

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "font-serif uppercase text-bold inline-flex items-center text-[10px] border rounded-full px-2 py-0.5 transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint-config-prettier": "^9.0.0",
     "form-data": "^4.0.0",
     "jest": "^29.7.0",
-    "lucide-react": "^0.292.0",
+    "lucide-react": "^0.417.0",
     "mongodb": "^6.2.0",
     "mongoose": "^8.0.0",
     "next": "14.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,8 +129,8 @@ dependencies:
     specifier: ^29.7.0
     version: 29.7.0(@types/node@20.14.11)(ts-node@10.9.2)
   lucide-react:
-    specifier: ^0.292.0
-    version: 0.292.0(react@18.3.1)
+    specifier: ^0.417.0
+    version: 0.417.0(react@18.3.1)
   mongodb:
     specifier: ^6.2.0
     version: 6.8.0
@@ -6217,10 +6217,10 @@ packages:
       yallist: 4.0.0
     dev: false
 
-  /lucide-react@0.292.0(react@18.3.1):
-    resolution: {integrity: sha512-rRgUkpEHWpa5VCT66YscInCQmQuPCB1RFRzkkxMxg4b+jaL0V12E3riWWR2Sh5OIiUhCwGW/ZExuEO4Az32E6Q==}
+  /lucide-react@0.417.0(react@18.3.1):
+    resolution: {integrity: sha512-F/MDUHDter8YMZ7JKQpW/5/+v38tdaoShKX3e+opYsqfCnaHwn+5zz3+lBrMDFMNtSsvxtNpchLIaMpEfsi/4w==}
     peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
     dependencies:
       react: 18.3.1
     dev: false


### PR DESCRIPTION
This commit introduces a new feature that allows employers to view CVs that match their job listings. The core functionality is implemented in a new action, `getMatchingJobsCvs`, which retrieves candidates whose profiles match the job title and occupation specified in a job listing. This action integrates with the existing database queries and file metadata retrieval functions to provide a comprehensive list of matching CVs.

Additionally, the commit includes updates to the employer dashboard job listing page to display these matching CVs. The page now fetches and displays candidates based on the job's title and occupation, with pagination controls for easier navigation through the list of candidates. The candidate list component has been updated to support a customizable background and card background color, enhancing the visual consistency across different sections of the application.

Furthermore, the commit updates the `lucide-react` package to a newer version, ensuring compatibility with the latest icons and features provided by the library. This update includes the addition of the `EllipsisVertical` icon used in the candidate actions component, replacing the previous custom SVG implementation.

Overall, this commit enhances the job matching and candidate search capabilities for employers, improving the user experience and functionality of the application.