### PR TITLE
Add user settings link to employer dashboard

### DIFF
--- a/app/api/candidates/[id]/route.ts
+++ b/app/api/candidates/[id]/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { getCurrentSessionUser } from "@/lib/auth";
+import { Role } from "@prisma/client";
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const user = await getCurrentSessionUser();
+    if (!user || user.role !== Role.EMPLOYER) {
+      return NextResponse.json(
+        { message: "Unauthorized", status: 401 },
+        { status: 401 },
+      );
+    }
+
+    const { id } = params;
+    const candidate = await db.candidate.findFirst({
+      where: {
+        candidateId: id,
+        employerId: user.id,
+      },
+    });
+
+    if (!candidate) {
+      return NextResponse.json(
+        { message: "Forbidden", status: 403 },
+        { status: 403 },
+      );
+    }
+
+    await db.candidate.delete({
+      where: {
+        id: candidate.id,
+      },
+    });
+
+    return NextResponse.json(
+      { message: "Success", status: 200 },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.log("[USER_ID]", error);
+    return NextResponse.json(
+      { message: "Internal Error", status: 500 },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/jobs/[id]/route.ts
+++ b/app/api/jobs/[id]/route.ts
@@ -45,3 +45,32 @@ export async function PATCH(
     return new NextResponse("Internal Error", { status: 500 });
   }
 }
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const user = await getCurrentSessionUser();
+    if (!user || user.role !== Role.EMPLOYER) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    const { id } = params;
+    await db.job.delete({
+      where: {
+        id: id,
+      },
+    });
+    return NextResponse.json(
+      { message: "Internal Error", status: 200 },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.log("[USER_ID]", error);
+    return NextResponse.json(
+      { message: "Internal Error", status: 500 },
+      { status: 500 },
+    );
+  }
+}

--- a/app/profile/dashboard/employer/candidates/[candidateId]/page.tsx
+++ b/app/profile/dashboard/employer/candidates/[candidateId]/page.tsx
@@ -5,13 +5,15 @@ import { getCurrentSessionUser } from "@/lib/auth";
 import { Role } from "@prisma/client";
 import { getUserCv } from "@/actions/get-user-cv";
 import UploadCV from "@/components/dashboard/job-seeker/cv/UploadCV";
-import { Settings } from "lucide-react";
+import { ArrowLeft, Settings } from "lucide-react";
 import { getLatestFileMetaData } from "@/actions/get-latest-file-metadata";
 import { getAllSectors } from "@/actions/get-all-sectors";
 import { getEducationLevels } from "@/actions/get-education-levels";
 import { getExperience } from "@/actions/get-experience";
 import JobSeekerProfileUpdate from "@/components/dashboard/job-seeker/cv/JobSeekerProfile";
 import StepsWrapper from "@/components/dashboard/job-seeker/cv/StepsWrapper";
+import Link from "next/link";
+import { CandidateActions } from "@/components/dashboard/employer/candidates/CandidateActions";
 
 type Props = {
   params: {
@@ -31,6 +33,15 @@ const page = async (props: Props) => {
 
   return (
     <div className="p-6">
+      <div className="flex items-center justify-between">
+        <Link
+          href="/profile/dashboard/employer/jobs"
+          className="text-primary hover:text-sky-500 "
+        >
+          <ArrowLeft className="h-6 w-6" />
+        </Link>
+        <CandidateActions candidateId={props.params.candidateId} />
+      </div>
       {jobSeekerProfile && (
         <StepsWrapper
           jobSeekerProfile={jobSeekerProfile}

--- a/app/profile/dashboard/employer/jobs/[id]/page.tsx
+++ b/app/profile/dashboard/employer/jobs/[id]/page.tsx
@@ -19,6 +19,7 @@ import CandidateList from "@/components/find-candidates/CandidateList";
 import { getCurrentSessionUser } from "@/lib/auth";
 import { Role } from "@prisma/client";
 import { getEmployerCandidatesIds } from "@/actions/get-employer-candidates-ids";
+import { JobActions } from "@/components/dashboard/employer/jobs/JobActions";
 
 type Props = {
   params: {
@@ -63,12 +64,15 @@ const page = async ({ params, searchParams }: Props) => {
 
   return (
     <div className="space-y-4 p-6">
-      <Link
-        href="/profile/dashboard/employer/jobs"
-        className="text-primary hover:text-sky-500 "
-      >
-        <ArrowLeft className="h-6 w-6" />
-      </Link>
+      <div className="flex items-center justify-between">
+        <Link
+          href="/profile/dashboard/employer/jobs"
+          className="text-primary hover:text-sky-500 "
+        >
+          <ArrowLeft className="h-6 w-6" />
+        </Link>
+        <JobActions jobId={jobId} />
+      </div>
       <div className="justify-between gap-4 rounded-md bg-white p-8 shadow-[rgba(17,_17,_26,_0.1)_0px_0px_16px]">
         <h1 className="my-4 flex items-center gap-4 text-2xl font-bold">
           {job.title}

--- a/app/profile/dashboard/employer/page.tsx
+++ b/app/profile/dashboard/employer/page.tsx
@@ -9,6 +9,7 @@ import {
   MapPin,
   Pencil,
   PhoneIcon,
+  UserCogIcon,
 } from "lucide-react";
 import Link from "next/link";
 import { redirect } from "next/navigation";
@@ -48,6 +49,13 @@ const page = async () => {
             </p>
           </div>
           <div className="flex-1">
+            <Link
+              href={`/profile/settings`}
+              className="my-4 flex items-center gap-4 text-lg font-bold hover:text-zinc-500"
+            >
+              <UserCogIcon className="h-6 w-6 text-primary" />
+              {employer.profile?.firstName} {employer.profile?.lastName}
+            </Link>
             <p className="my-4 flex items-center gap-4 text-sm">
               <PhoneIcon className="h-6 w-6 text-primary" />
               {employer.profile?.phoneNumber}

--- a/components/dashboard/employer/candidates/CandidateActions.tsx
+++ b/components/dashboard/employer/candidates/CandidateActions.tsx
@@ -8,11 +8,11 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { ConfirmModal } from "@/components/modals/ConfirmModal";
 
-interface JobActionsProps {
-  jobId: string;
+interface CandidateActionsProps {
+  candidateId: string;
 }
 
-export const JobActions = ({ jobId }: JobActionsProps) => {
+export const CandidateActions = ({ candidateId }: CandidateActionsProps) => {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
 
@@ -20,12 +20,12 @@ export const JobActions = ({ jobId }: JobActionsProps) => {
     try {
       setIsLoading(true);
 
-      const response = await fetch(`/api/jobs/${jobId}/`, {
+      const response = await fetch(`/api/candidates/${candidateId}/`, {
         method: "DELETE",
       });
       const { message, status } = await response.json();
-
-      if (status === 200) {
+      console.log(message, status, "---------------------------");
+      if (response.status === 200) {
         toast({
           title: "Success",
           description: "Resource deleted successfuly.",
@@ -39,7 +39,7 @@ export const JobActions = ({ jobId }: JobActionsProps) => {
           variant: "destructive",
         });
       }
-      router.push("/profile/dashboard/employer/jobs/");
+      router.push("/profile/dashboard/employer/candidates/");
     } catch {
       toast({
         title: "Error",

--- a/components/dashboard/employer/candidates/Columns.tsx
+++ b/components/dashboard/employer/candidates/Columns.tsx
@@ -45,7 +45,7 @@ export const columns: ColumnDef<CandidateProps>[] = [
     },
   },
   {
-    accessorKey: "jobSeekerProfile.cvHeadline",
+    accessorKey: "jobSeekerProfile.cvHeadLine",
     header: ({ column }) => {
       return (
         <Button
@@ -59,9 +59,9 @@ export const columns: ColumnDef<CandidateProps>[] = [
     },
   },
   {
-    accessorKey: "phoneNumber",
+    accessorKey: "profile.phoneNumber",
     header: ({ column }) => {
-      return <p>Phone Number</p>;
+      return <p className="px-4 py-2">Phone Number</p>;
     },
   },
   {

--- a/components/dashboard/employer/jobs/JobActions.tsx
+++ b/components/dashboard/employer/jobs/JobActions.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Loader2, Trash } from "lucide-react";
+import { useState } from "react";
+import { toast } from "@/components/ui/use-toast";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { ConfirmModal } from "@/components/modals/ConfirmModal";
+
+interface JobActionsProps {
+  jobId: string;
+}
+
+export const JobActions = ({ jobId }: JobActionsProps) => {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const onDelete = async () => {
+    try {
+      setIsLoading(true);
+
+      const response = await fetch(`/api/jobs/${jobId}/`, {
+        method: "DELETE",
+      });
+      const data = await response.json();
+      if (response.status === 200) {
+        toast({
+          title: "Success",
+          description: "Resource deleted successfuly.",
+          variant: "default",
+          className: "bg-green-300 border-0",
+        });
+      } else {
+        toast({
+          title: "Error",
+          description: data,
+          variant: "destructive",
+        });
+      }
+      router.refresh();
+      router.push("/profile/dashboard/employer/jobs/");
+    } catch {
+      toast({
+        title: "Error",
+        description: "Something went wrong.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-x-2">
+      <ConfirmModal onConfirm={onDelete}>
+        <Button size="sm" disabled={isLoading}>
+          {isLoading ? (
+            <Loader2 className="h-8 w-8 animate-spin text-secondary" />
+          ) : (
+            <Trash className="h-4 w-4" />
+          )}
+        </Button>
+      </ConfirmModal>
+    </div>
+  );
+};

--- a/components/dashboard/job-seeker/cv/StepsWrapper.tsx
+++ b/components/dashboard/job-seeker/cv/StepsWrapper.tsx
@@ -145,7 +145,7 @@ const StepsWrapper = ({
   return (
     <div className="space-y-8 bg-slate-100/30 p-12">
       <h4 className="scroll-m-20 py-2 text-4xl  tracking-tight first:mt-0">
-        My Profile
+        Profile
       </h4>
       {/* top bar  */}
       <div className="flex flex-wrap items-center justify-between gap-4 rounded-md bg-white p-4 shadow-[0_3px_10px_rgb(0,0,0,0.2)]">
@@ -155,7 +155,7 @@ const StepsWrapper = ({
             variant={index === currentStepIndex ? "default" : "outline"}
             className={cn(
               currentStepIndex === index &&
-                " p-2 bg-sky-500/20 text-zinc-100 hover:bg-sky-500/20",
+                " bg-sky-500/20 p-2 text-zinc-100 hover:bg-sky-500/20",
               "text-xshover:text-slate-500 flex-1 cursor-pointer justify-center border-none  text-center text-zinc-700",
             )}
             onClick={() => goTo(index)}


### PR DESCRIPTION
This commit introduces a new link to the user settings page within the employer
dashboard. The link is represented by the `UserCogIcon` from the `lucide-react`
library and is placed alongside other profile details such as the phone number.
This enhancement allows employers to easily navigate to their settings directly
from the dashboard, improving user experience and workflow efficiency.