### PR TITLE
Adjust line height for swiper-slide-content headings

### DIFF
--- a/components/index/styles.css
+++ b/components/index/styles.css
@@ -66,7 +66,7 @@ body {
 .swiper-slide-content h1 {
   font-size: calc(2vw + 5vh);
   letter-spacing: 2px;
-  line-height: calc(3vw + 6vh);
+  line-height: calc(2vw + 6vh);
   text-transform: capitalize;
   font-weight: 400;
   margin-bottom: 1rem;


### PR DESCRIPTION
The line height for headings within swiper-slide-content elements was adjusted from calc(3vw + 6vh) to calc(2vw + 6vh) to improve readability and alignment with the design specifications. This change ensures that the text layout remains consistent across different viewport sizes, enhancing the overall user experience.