### PR TITLE
Remove unused office building icon from JobCard component

### DIFF
--- a/components/job/JobCard.tsx
+++ b/components/job/JobCard.tsx
@@ -54,10 +54,8 @@ const JobCard = ({
               </div>
             )}
           </div>
-          <Icon
-            icon="mdi:office-building"
-            className="h-16 w-16 text-gray-500"
-          />
+          {/* add company logo if needed */}
+          
         </div>
         <div className="mb-4 text-sm text-gray-600">
           <div className="mb-1 flex items-center gap-1">


### PR DESCRIPTION
The office building icon was previously included in the JobCard component, but it is no longer needed. This commit removes the unused Icon component and adds a placeholder comment for future company logo implementation. This change helps to declutter the component and prepares it for future enhancements.